### PR TITLE
feat(commit): enhance commitlint configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project uses Calendar Versioning (YYYY.MM.MINOR).
 - GitHub workflow to update changelog on PR merges
 - Switched to Calendar Versioning
 - Added GitHub Actions status badge to README.md
+- Enhanced commitlint configuration with better documentation and additional rules:
+  - Added detailed comments for each commit type
+  - Added new rules for body and footer formatting
+  - Improved overall code documentation
 
 ## [2024.12.2] - 2024-12-14
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,7 @@
+/**
+ * Commitlint configuration for enforcing Angular commit convention
+ * See: https://github.com/conventional-changelog/commitlint
+ */
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
@@ -5,24 +9,27 @@ module.exports = {
       2,
       'always',
       [
-        'feat',    // New feature
-        'fix',     // Bug fix
-        'docs',    // Documentation only changes
-        'style',   // Changes that do not affect the meaning of the code
-        'refactor',// A code change that neither fixes a bug nor adds a feature
-        'perf',    // A code change that improves performance
-        'test',    // Adding missing tests or correcting existing tests
-        'build',   // Changes that affect the build system or external dependencies
-        'ci',      // Changes to our CI configuration files and scripts
-        'chore',   // Other changes that don't modify src or test files
-        'revert',  // Reverts a previous commit
+        'feat',     // New feature for the user
+        'fix',      // Bug fix for the user
+        'docs',     // Documentation only changes
+        'style',    // Changes that do not affect the meaning of the code (white-space, formatting, etc)
+        'refactor', // A code change that neither fixes a bug nor adds a feature
+        'perf',     // A code change that improves performance
+        'test',     // Adding missing tests or correcting existing tests
+        'build',    // Changes that affect the build system or external dependencies
+        'ci',       // Changes to our CI configuration files and scripts
+        'chore',    // Other changes that don't modify src or test files
+        'revert',   // Reverts a previous commit
       ],
     ],
-    'type-case': [2, 'always', 'lower'],
-    'type-empty': [2, 'never'],
-    'scope-case': [2, 'always', 'lower'],
-    'subject-empty': [2, 'never'],
-    'subject-full-stop': [2, 'never', '.'],
-    'header-max-length': [2, 'always', 72],
+    'type-case': [2, 'always', 'lowerCase'],      // Type must be lowercase
+    'type-empty': [2, 'never'],                   // Type cannot be empty
+    'scope-case': [2, 'always', 'lowerCase'],     // Scope must be lowercase
+    'subject-empty': [2, 'never'],                // Subject cannot be empty
+    'subject-full-stop': [2, 'never', '.'],       // Subject cannot end with period
+    'header-max-length': [2, 'always', 72],       // Header has a maximum length
+    'body-leading-blank': [2, 'always'],          // Body should have leading blank line
+    'footer-leading-blank': [1, 'always'],        // Footer should have leading blank line
+    'body-max-line-length': [2, 'always', 100],   // Body lines should not exceed 100 chars
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
   "packages": {
     "": {
       "version": "2024.12.2",
+      "hasInstallScript": true,
       "devDependencies": {
         "@commitlint/cli": "^19.6.0",
         "@commitlint/config-conventional": "^19.6.0",


### PR DESCRIPTION
This PR enhances our commitlint configuration with better documentation and additional rules.

### Changes
- Added detailed comments for each commit type
- Added new rules for body and footer formatting:
  - body-leading-blank: Enforce blank line before body
  - footer-leading-blank: Enforce blank line before footer
  - body-max-line-length: Limit body lines to 100 characters
- Improved overall code documentation with JSDoc style header
- Updated CHANGELOG.md to reflect these changes
- Updated package-lock.json