### PR TITLE
release: 2024.12.6

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Update package.json version
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          npm version $VERSION --no-git-tag-version
+          CURRENT_VERSION=$(npm pkg get version | tr -d '"')
+          if [ "$VERSION" != "$CURRENT_VERSION" ]; then
+            npm version $VERSION --no-git-tag-version
+          fi
 
       - name: Create Pull Request comment
         uses: actions/github-script@v7

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -6,7 +6,7 @@ name: Create Release Tag
 
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
     branches: [main]
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "awesome-windsurf",
   "description": "A curated hub of awesome Windsurf resources",
-  "version": "2024.12.3",
+  "version": "2024.12.6",
   "private": false,
   "devDependencies": {
     "@commitlint/cli": "^19.6.0",


### PR DESCRIPTION
Fix for release 2024.12.6:

1. Updated package.json version to 2024.12.6
2. This should allow the publish workflow to create the correct tag
3. Once merged, we'll get proper release notes with our new categories