### PR TITLE
fix: configure git user for release tag creation

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Create and push tag
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          git config --global user.email "action@github.com"
+          git config --global user.name "GitHub Action"
           git tag -a $VERSION -m "Release $VERSION"
           git push origin $VERSION
         env:


### PR DESCRIPTION
Part of #27 - Adds proper git user configuration for GitHub Action to create release tags.

This PR adds the necessary git configuration to ensure the GitHub Action can properly create and push tags during the release process.