### PR TITLE
update: implement automatic release workflow

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,7 +1,3 @@
-# This workflow creates git tags when release PRs are merged.
-# It ensures that each release has a corresponding git tag,
-# making it easier to track versions and generate changelogs.
-
 name: Create Release Tag
 
 on:
@@ -10,47 +6,141 @@ on:
     branches: [main]
 
 jobs:
-  create-tag:
+  check-changes:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.pull_request.title, 'release:')
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
+    outputs:
+      should_release: ${{ steps.check.outputs.should_release }}
+      new_version: ${{ steps.version.outputs.version }}
+      is_manual_release: ${{ steps.check.outputs.is_manual_release }}
     
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Get version from PR title
+      - name: Check if release needed
+        id: check
+        run: |
+          # Check for manual release commit
+          LAST_COMMIT_MSG=$(git log -1 --pretty=%B)
+          if [[ "$LAST_COMMIT_MSG" =~ ^release: ]]; then
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "is_manual_release=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Count changed files
+          FILES_CHANGED=$(git diff --name-only origin/main HEAD | wc -l)
+          # Count commits since last release
+          COMMITS_COUNT=$(git rev-list $(git describe --tags --abbrev=0)..HEAD --count)
+          
+          if [ $FILES_CHANGED -gt 5 ] || [ $COMMITS_COUNT -gt 10 ]; then
+            echo "should_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_release=false" >> $GITHUB_OUTPUT
+          fi
+          echo "is_manual_release=false" >> $GITHUB_OUTPUT
+
+      - name: Calculate new version
         id: version
+        if: steps.check.outputs.should_release == 'true'
         run: |
-          PR_TITLE="${{ github.event.pull_request.title }}"
-          # Extract version after "release:" prefix
-          VERSION=$(echo "$PR_TITLE" | sed 's/^release: *//i')
-          # Validate CalVer format (YYYY.MM.PATCH)
-          if [[ ! $VERSION =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]+$ ]]; then
-            echo "Invalid version format. Must be YYYY.MM.PATCH"
-            exit 1
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Update package.json version
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
+          # Get current date components
+          YEAR=$(date +%Y)
+          MONTH=$(date +%m)
+          
+          # Get current version from package.json
           CURRENT_VERSION=$(npm pkg get version | tr -d '"')
-          if [ "$VERSION" != "$CURRENT_VERSION" ]; then
-            npm version $VERSION --no-git-tag-version
+          
+          # If current version matches current year/month, increment patch
+          if [[ $CURRENT_VERSION =~ ^$YEAR\.$MONTH\.[0-9]+$ ]]; then
+            PATCH=$(echo $CURRENT_VERSION | cut -d. -f3)
+            PATCH=$((PATCH + 1))
+          else
+            # New year/month, start at patch 1
+            PATCH=1
           fi
+          
+          NEW_VERSION="$YEAR.$MONTH.$PATCH"
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Create Pull Request comment
+      - name: Update PR with version info
+        if: steps.check.outputs.should_release == 'true'
         uses: actions/github-script@v7
         with:
           script: |
             const version = "${{ steps.version.outputs.version }}"
+            const isManual = "${{ steps.check.outputs.is_manual_release }}" === "true"
+            const message = isManual 
+              ? `📦 Manual release \`${version}\` will be created when this PR is merged.`
+              : `📦 Changes detected! Version \`${version}\` will be created when this PR is merged.`
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `✨ Version \`${version}\` will be created when this PR is merged.`
+              body: message
             })
+
+  check-release-status:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check release status
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            
+            const hasVersionBump = pr.labels.some(label => label.name === 'version-bump');
+            const lastCommit = await github.rest.repos.getCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: pr.head.sha
+            });
+            const isManualRelease = lastCommit.data.commit.message.startsWith('release:');
+            
+            const state = (hasVersionBump || isManualRelease) ? 'success' : 'pending';
+            const description = (hasVersionBump || isManualRelease) 
+              ? 'Ready for release' 
+              : 'Waiting for release approval';
+            
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: pr.head.sha,
+              state,
+              description,
+              context: 'Release Status'
+            });
+
+  update-version:
+    needs: check-changes
+    if: needs.check-changes.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - uses: actions/checkout@v4
+        
+      - name: Update package.json version
+        run: |
+          VERSION="${{ needs.check-changes.outputs.new_version }}"
+          npm version $VERSION --no-git-tag-version

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'release:')
+    # Only run if PR was merged and has a version update
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'version-bump')
     permissions:
       contents: write
     

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,23 +87,32 @@ Every contribution makes Windsurf better for everyone. Don't hesitate to:
 
 ## Release Process
 
-We use GitHub Releases to document changes to this repository. Each release follows the Calendar Versioning format (YYYY.MM.PATCH).
+Our releases are managed through an automated GitHub workflow:
 
-### Pull Request Labels
+### Version Format
 
-To help organize our releases, we use a simple labeling system:
+We use Calendar Versioning (CalVer) with the format: YYYY.MM.PATCH
+Example: 2024.12.1
 
-- `content`: For documentation, guides, and content changes
-- `meta`: For repository maintenance and workflow changes
+### Release Labels
 
-### Creating a Release
+When your PR is ready for release:
 
-Releases are automatically generated based on merged pull requests and their labels. The process is:
+- Add the `release` label to trigger the release workflow
+- Use additional labels to categorize changes:
+  - `content`: Documentation and content changes
+  - `meta`: Repository maintenance and workflow changes
 
-1. PRs are labeled appropriately during review
-2. When ready for a release, we create a new GitHub Release
-3. Release notes are automatically generated based on PR labels
-4. The release version follows YYYY.MM.PATCH format
+### Automated Processes
+
+Our release workflow handles:
+
+- Version bumping based on CalVer
+- Changelog generation from commit history
+- GitHub release creation with categorized notes
+- Git tag creation and management
+
+Note: All changes are merged through our merge queue for additional safety, as direct pushes to main are not allowed.
 
 ## Contributing Prompts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,30 +87,48 @@ Every contribution makes Windsurf better for everyone. Don't hesitate to:
 
 ## Release Process
 
-Our releases are managed through an automated GitHub workflow:
+Our releases are managed through an automated GitHub workflow that monitors changes and creates releases when significant updates occur. Every merge to the `main` branch results in a release, ensuring that the public repository always reflects released versions.
 
-### Version Format
+### Merging to Main
 
-We use Calendar Versioning (CalVer) with the format: YYYY.MM.PATCH
-Example: 2024.12.1
+PRs can only be merged to `main` when they are ready for release. This is enforced by requiring either:
 
-### Release Labels
+- The `version-bump` label (added automatically when changes are significant), or
+- A commit message starting with `release:`
 
-When your PR is ready for release:
+This ensures that all changes in the public repository are properly versioned and released.
 
-- Add the `release` label to trigger the release workflow
-- Use additional labels to categorize changes:
-  - `content`: Documentation and content changes
-  - `meta`: Repository maintenance and workflow changes
+### Automatic Releases
 
-### Automated Processes
+A new release is automatically created when:
 
-Our release workflow handles:
+- More than 5 files are changed in a PR, or
+- More than 10 commits have been made since the last release
 
-- Version bumping based on CalVer
-- Changelog generation from commit history
-- GitHub release creation with categorized notes
-- Git tag creation and management
+### Manual Releases
+
+You can trigger a release manually by including a commit with a message that starts with `release:` followed by a description of your changes:
+
+```bash
+git commit -m "release: major update to custom prompts section"
+```
+
+The version number will be calculated automatically based on the current date (YYYY.MM) and incrementing the patch number from the last release.
+
+### Release Process
+
+The workflow will:
+
+1. Calculate the next version number using Calendar Versioning (YYYY.MM.PATCH)
+2. Update package.json with the new version
+3. Add a comment to your PR with the upcoming version
+4. Add the `version-bump` label to your PR
+
+When the PR is merged:
+
+- A new git tag is created
+- A GitHub release is published
+- Release notes are automatically generated
 
 Note: All changes are merged through our merge queue for additional safety, as direct pushes to main are not allowed.
 


### PR DESCRIPTION
Closes #27

Implements a simpler release workflow that:
- Automatically detects when changes warrant a release
- Supports manual releases via 'release:' commits
- Always uses automatic version calculation
- Enforces releases for all merges to main