### PR TITLE
fix: use correct release label in publish workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    # Only run if PR was merged and has a version update
-    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'version-bump')
+    # Only run if PR was merged and has a release label
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
     permissions:
       contents: write
     


### PR DESCRIPTION
Updates the publish-release workflow to use the 'release' label instead of 'version-bump'.