### PR TITLE
add: automatic release label workflow

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -12,6 +12,10 @@ jobs:
       pull-requests: write
     
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
       - name: Check commit messages and add label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,26 @@
+name: Auto Label Release PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [main]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    
+    steps:
+      - name: Check commit messages and add label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Get all commit messages in the PR
+          commits=$(gh pr view $PR_NUMBER --json commits --jq '.commits[].messageHeadline')
+          
+          # Check if any commit message starts with "release:"
+          if echo "$commits" | grep -q "^release:"; then
+            gh pr edit $PR_NUMBER --add-label "release"
+          fi


### PR DESCRIPTION
This PR adds a new GitHub Actions workflow that automatically adds the 'release' label to pull requests when they contain a commit message starting with 'release:'

### Changes
- Added new `.github/workflows/auto-label.yml` workflow
- Workflow triggers on PR open/sync events
- Checks commit messages for 'release:' prefix
- Automatically adds 'release' label when found

This will streamline our release process by automating the label application step.