### PR TITLE
fix: align dependabot commit prefix with commitlint config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,5 @@ updates:
     labels:
       - 'dependencies'
     commit-message:
-      prefix: 'chore'
+      prefix: 'update'
       include: 'scope'


### PR DESCRIPTION
Updates the Dependabot configuration to use 'update' as the commit prefix instead of 'chore' to match our commitlint configuration which only allows: [add, update, remove, fix, meta, release].