### PR TITLE
add: add LynxPrompt to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Join our community on [Discord](https://discord.gg/3XFf78nAx5) (badge above) or 
 
 ## Community Resources
 
-- [LynxPrompt](https://github.com/GeiserX/LynxPrompt)
+- [LynxPrompt by GeiserX](https://github.com/GeiserX/LynxPrompt)
 - [windsurfrules by kinopeee](https://github.com/kinopeee/windsurfrules)
 - [windsurfrules_by_kamusis](https://github.com/kamusis/windsurf_memories)
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Join our community on [Discord](https://discord.gg/3XFf78nAx5) (badge above) or 
 
 ## Community Resources
 
-- [LynxPrompt](https://github.com/GeiserX/LynxPrompt) - Self-hostable platform for managing AI IDE configuration files. Generates, syncs, and shares Windsurf configs (and 30+ other AI coding assistant formats) via web UI, REST API, CLI, and federated blueprint marketplace. ([Website](https://lynxprompt.com))
+- [LynxPrompt](https://github.com/GeiserX/LynxPrompt)
 - [windsurfrules by kinopeee](https://github.com/kinopeee/windsurfrules)
 - [windsurfrules_by_kamusis](https://github.com/kamusis/windsurf_memories)
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Join our community on [Discord](https://discord.gg/3XFf78nAx5) (badge above) or 
 
 ## Community Resources
 
+- [LynxPrompt](https://github.com/GeiserX/LynxPrompt) - Self-hostable platform for managing AI IDE configuration files. Generates, syncs, and shares Windsurf configs (and 30+ other AI coding assistant formats) via web UI, REST API, CLI, and federated blueprint marketplace. ([Website](https://lynxprompt.com))
 - [windsurfrules by kinopeee](https://github.com/kinopeee/windsurfrules)
 - [windsurfrules_by_kamusis](https://github.com/kamusis/windsurf_memories)
 


### PR DESCRIPTION
## Summary

- Adds [LynxPrompt](https://github.com/GeiserX/LynxPrompt) to the **Community Resources** section
- LynxPrompt is a self-hostable platform for managing AI IDE configuration files, supporting Windsurf and 30+ other AI coding assistant formats
- Entry placed in alphabetical order within the section

## Details

- **Name**: LynxPrompt
- **URL**: https://github.com/GeiserX/LynxPrompt
- **Website**: https://lynxprompt.com
- **License**: GPL-3.0
- **What it does**: Generates, syncs, and shares Windsurf configs via web UI, REST API, CLI, and federated blueprint marketplace
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/awesome-windsurf/pull/255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
