### PR TITLE
Add agentskill.sh to community resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Join our community on [Discord](https://discord.gg/3XFf78nAx5) (badge above) or 
 
 - [windsurfrules by kinopeee](https://github.com/kinopeee/windsurfrules)
 - [windsurfrules_by_kamusis](https://github.com/kamusis/windsurf_memories)
+- [agentskill.sh](https://agentskill.sh) - Browse and install 69,000+ AI agent skills for Windsurf and 20+ other AI tools
 
 ## Community Prompts
 


### PR DESCRIPTION
Adds [agentskill.sh](https://agentskill.sh) to the Community Resources section.

agentskill.sh is a directory of 100k+ AI agent skills with one-click install for Windsurf

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/awesome-windsurf/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
