### PR TITLE
Add Helium MCP to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A curated hub of resources, tips, and community-driven content for Windsurf - a 
 - [Useful Links](#useful-links)
 - [FAQ](#faq)
 - [Community Resources](#community-resources)
+- [MCP Servers](#mcp-servers)
 - [Community Prompts](#community-prompts)
 - [Tips and Tricks](#tips-and-tricks)
 - [Videos](#videos)
@@ -50,6 +51,16 @@ Join our community on [Discord](https://discord.gg/3XFf78nAx5) (badge above) or 
 
 - [windsurfrules by kinopeee](https://github.com/kinopeee/windsurfrules)
 - [windsurfrules_by_kamusis](https://github.com/kamusis/windsurf_memories)
+
+## MCP Servers
+
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) — Works natively with Windsurf via one config paste:
+
+  ```json
+  {"mcpServers": {"helium": {"serverUrl": "https://heliumtrades.com/mcp"}}}
+  ```
+
+  Provides 10 tools: news search, balanced news, source/article bias, ticker data, options pricing, historical options, top strategies, meme search.
 
 ## Community Prompts
 


### PR DESCRIPTION
Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) to a new **MCP Servers** section with Windsurf-native `serverUrl` config and a short summary of the 10 tools.

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/awesome-windsurf/pull/326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
