### PR TITLE
Add Agent Shadow Brain and Omni Skills Forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Want to contribute? Create a directory with your username and add your prompts! 
 - Don't trust it blindly.
 - Keep an eye on your **Problems** panel at the bottom.
 - Arguably, it's even more important to have very solid testing code in place when using AI coding tools.
+- **[Agent Shadow Brain](https://github.com/theihtisham/agent-shadow-brain)** - Self-evolving AI coding intelligence with infinite memory (TurboQuant), genetic algorithm self-evolution, predictive bug detection, PageRank knowledge graphs, swarm intelligence, and adversarial defense.
+- **[Omni Skills Forge](https://github.com/theihtisham/omni-skills-forge)** - 50,000+ curated AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Cline. Visual dashboard, one-click install, skill doctor, auto-update.
 
 ## Contributing
 


### PR DESCRIPTION
## Added
- **[Agent Shadow Brain](https://github.com/theihtisham/agent-shadow-brain)** - Self-evolving AI coding intelligence with infinite memory (TurboQuant), genetic algorithm self-evolution, predictive bug detection, PageRank knowledge graphs, swarm intelligence, and adversarial defense.
- **[Omni Skills Forge](https://github.com/theihtisham/omni-skills-forge)** - 50,000+ curated AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Cline. Visual dashboard, one-click install, skill doctor, auto-update.

Both are actively maintained open-source projects. TypeScript/Node.js. MIT licensed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/awesome-windsurf/pull/327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two external project links — Agent Shadow Brain and Omni Skills Forge — both authored by the PR submitter (`theihtisham`). The entries are placed incorrectly inside the **Caveats** bullet list under the "Tips and Tricks" section rather than in `## Community Resources`, where similar project links already live.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — the new entries are placed in the wrong section of the README.

The sole change is a README edit, but the two bullet points are inserted into the Caveats list under Tips and Tricks rather than the Community Resources section. This makes the document structurally incorrect and confusing for readers.

README.md — insertion point needs to move to the Community Resources section.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds two external project links (Agent Shadow Brain, Omni Skills Forge) in the wrong section — appended inside the Caveats bullet list under Tips and Tricks instead of Community Resources. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md] --> B[Community Resources]
    A --> C[Tips and Tricks]
    C --> D["4. Caveats bullet list"]
    D --> E["❌ Agent Shadow Brain (added here)"]
    D --> F["❌ Omni Skills Forge (added here)"]
    B --> G["✅ Correct location for project links"]
    style E fill:#ff6b6b
    style F fill:#ff6b6b
    style G fill:#6bcb77
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A80-81%0A**Wrong%20section%20placement**%0A%0AThese%20two%20entries%20are%20inserted%20inside%20the%20**Caveats**%20bullet%20list%20under%20%22Tips%20and%20Tricks%22%20%28point%204%29%2C%20but%20they%20are%20external%20project%20links%20%E2%80%94%20not%20caveats%20about%20using%20Windsurf.%20They%20should%20belong%20in%20the%20%60%23%23%20Community%20Resources%60%20section%20%28lines%2049%E2%80%9352%29%2C%20alongside%20similar%20project%20links%20like%20%60windsurfrules%60.%20As-is%2C%20they%20render%20as%20continuation%20bullets%20of%20the%20%22Be%20CAREFUL%22%20caveats%20paragraph%2C%20which%20is%20contextually%20misleading.%0A%0A&repo=detailobsessed%2Fawesome-windsurf&pr=327&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: README.md
Line: 80-81

Comment:
**Wrong section placement**

These two entries are inserted inside the **Caveats** bullet list under "Tips and Tricks" (point 4), but they are external project links — not caveats about using Windsurf. They should belong in the `## Community Resources` section (lines 49–52), alongside similar project links like `windsurfrules`. As-is, they render as continuation bullets of the "Be CAREFUL" caveats paragraph, which is contextually misleading.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Agent Shadow Brain and Omni Skills F..."](https://github.com/detailobsessed/awesome-windsurf/commit/f2fc33a41d45aebfca588d5b06049fc90d7b1e94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28916178)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->