### PR TITLE
Add Emdash Skills to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Join our community on [Discord](https://discord.gg/3XFf78nAx5) (badge above) or 
 
 - [windsurfrules by kinopeee](https://github.com/kinopeee/windsurfrules)
 - [windsurfrules_by_kamusis](https://github.com/kamusis/windsurf_memories)
+- [Emdash Skills by megabytespace](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS with 18 agents and .windsurfrules compatibility
+
 
 ## Community Prompts
 


### PR DESCRIPTION
## Summary
- Adds [Emdash Skills](https://github.com/megabytespace/claude-skills) to the Community Resources section
- 14-category autonomous product-building OS with 18 agents and .windsurfrules compatibility
- Skills cover architecture, planning, quality verification, brand, media, observability, and deployment

## Entry format
Matches existing format: `- [name by author](url) - description`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/detailobsessed/awesome-windsurf/pull/328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single entry — Emdash Skills by megabytespace — to the Community Resources section of the README. All findings are P2 style/clarification items around a trailing blank line, description consistency, and the resource's primary focus (Claude vs. Windsurf).

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are minor style/clarification concerns with no functional impact.

Only P2 findings present — a superfluous blank line, a description that differs from existing entry conventions, and a relevance question. None of these block merging.

README.md — minor formatting and relevance clarification needed.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds one Community Resources entry for Emdash Skills; introduces a trailing blank line duplication and a description that is inconsistent with existing no-description entries in the same section. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[README.md Community Resources] --> B[windsurfrules by kinopeee]
    A --> C[windsurfrules_by_kamusis]
    A --> D["Emdash Skills by megabytespace NEW"]
    D --> E[github.com/megabytespace/claude-skills]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0AREADME.md%3A53-55%0A**Extra%20blank%20line%20introduced**%0A%0AThe%20diff%20adds%20an%20extra%20blank%20line%20after%20the%20new%20entry%2C%20leaving%20two%20consecutive%20blank%20lines%20before%20%60%23%23%20Community%20Prompts%60.%20The%20existing%20section%20ends%20with%20a%20single%20blank%20line%3B%20this%20adds%20an%20unnecessary%20second%20one.%0A%0A%60%60%60suggestion%0A-%20%5BEmdash%20Skills%20by%20megabytespace%5D%28https%3A%2F%2Fgithub.com%2Fmegabytespace%2Fclaude-skills%29%20-%2014-category%20autonomous%20product-building%20OS%20with%2018%20agents%20and%20.windsurfrules%20compatibility%0A%0A%23%23%20Community%20Prompts%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0AREADME.md%3A53%0A**Description%20absent%20from%20existing%20entries**%0A%0AThe%20PR%20description%20states%20this%20%22Matches%20existing%20format%2C%22%20but%20the%20two%20existing%20Community%20Resources%20entries%20%28%60windsurfrules%20by%20kinopeee%60%2C%20%60windsurfrules_by_kamusis%60%29%20have%20no%20description%20text.%20Adding%20a%20%60%20-%20%E2%80%A6%60%20description%20is%20inconsistent%20with%20the%20current%20pattern%20in%20this%20section.%0A%0A%23%23%23%20Issue%203%20of%203%0AREADME.md%3A53%0A**Repo%20name%20suggests%20Claude%20%28Anthropic%29%20focus%2C%20not%20Windsurf**%0A%0AThe%20linked%20repository%20is%20named%20%60claude-skills%60%20and%20the%20PR%20description%20references%20%2218%20agents%22%20%E2%80%94%20this%20appears%20to%20be%20a%20skill%20set%20targeting%20Anthropic's%20Claude%20rather%20than%20Windsurf%2FCodeium.%20The%20entry%20does%20mention%20%60.windsurfrules%20compatibility%60%2C%20but%20it%20is%20worth%20confirming%20that%20the%20resource%20is%20primarily%20a%20Windsurf%20community%20resource%20rather%20than%20a%20general%20Claude%2FLLM%20tool.%0A%0A&repo=detailobsessed%2Fawesome-windsurf&pr=328&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: README.md
Line: 53-55

Comment:
**Extra blank line introduced**

The diff adds an extra blank line after the new entry, leaving two consecutive blank lines before `## Community Prompts`. The existing section ends with a single blank line; this adds an unnecessary second one.

```suggestion
- [Emdash Skills by megabytespace](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS with 18 agents and .windsurfrules compatibility

## Community Prompts
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: README.md
Line: 53

Comment:
**Description absent from existing entries**

The PR description states this "Matches existing format," but the two existing Community Resources entries (`windsurfrules by kinopeee`, `windsurfrules_by_kamusis`) have no description text. Adding a ` - …` description is inconsistent with the current pattern in this section.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: README.md
Line: 53

Comment:
**Repo name suggests Claude (Anthropic) focus, not Windsurf**

The linked repository is named `claude-skills` and the PR description references "18 agents" — this appears to be a skill set targeting Anthropic's Claude rather than Windsurf/Codeium. The entry does mention `.windsurfrules compatibility`, but it is worth confirming that the resource is primarily a Windsurf community resource rather than a general Claude/LLM tool.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Add Emdash Skills to Awesome Windsurf co..."](https://github.com/detailobsessed/awesome-windsurf/commit/bac01ffea0a9abc1c36df7d4b5bec000732ec7cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29554299)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->