### PR TITLE
Add proof-of-commitment supply chain hook to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Join our community on [Discord](https://discord.gg/3XFf78nAx5) (badge above) or 
 
 - [windsurfrules by kinopeee](https://github.com/kinopeee/windsurfrules)
 - [windsurfrules_by_kamusis](https://github.com/kamusis/windsurf_memories)
+- [proof-of-commitment supply chain hook](https://github.com/piiiico/proof-of-commitment#ide-hooks-cursor--claude-code--windsurf) - Supply chain security gate for Windsurf. `poc hook --windsurf` intercepts `npm install`, `pip install`, `cargo add` and `go get` — blocks CRITICAL packages before they execute.
 
 ## Community Prompts
 


### PR DESCRIPTION
Adds the [proof-of-commitment](https://github.com/piiiico/proof-of-commitment) supply chain hook to Community Resources.

**What it does:** `poc hook --windsurf` installs a `pre_run_command` hook that intercepts package installs (`npm install`, `pip install`, `cargo add`, `go get`) and checks them against behavioral supply chain risk signals before execution. CRITICAL packages (single publisher + high download volume — the exact attack profile used in the axios and LiteLLM compromises) are blocked.

**Why it matters for Windsurf users:** The Shai-Hulud worm (May 2026) specifically targeted AI coding assistants, planting persistence hooks in IDE config files. When an AI agent installs dependencies autonomously, this hook is the gate that catches compromised packages.

Install: `npx proof-of-commitment hook --windsurf` (one command, writes `.windsurf/hooks.json`).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add proof-of-commitment supply chain hook to Community Resources in README
> Adds a new entry under the Community Resources section of [README.md](https://github.com/detailobsessed/awesome-windsurf/pull/332/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) linking to a proof-of-commitment supply chain hook for the Windsurf IDE, with a brief description of the commands it intercepts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b978d83.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->